### PR TITLE
fix: correct model paths and repo-type in README and code defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Download the TTS weights from [notmax123/LightBlue](https://huggingface.co/notma
 
 ```bash
 uv run hf download notmax123/LightBlue \
-  --repo-type onnx_model \
-  --local-dir ./onnx_model
+  --repo-type model \
+  --local-dir ./onnx_models
 wget https://huggingface.co/thewh1teagle/phonikud-onnx/resolve/main/phonikud-1.0.int8.onnx
 ```
 
@@ -31,7 +31,7 @@ uv run python run_onnx_inference.py \
 ```python
 from hebrew_inference_helper import HebrewTTS, TTSConfig
 
-tts = HebrewTTS(TTSConfig(onnx_dir="onnx_models", config_path="tts.json"))
+tts = HebrewTTS(TTSConfig(onnx_dir="./onnx_models"))
 wav = tts.infer("שלום עולם", style_json_path="voices/female1.json")
 ```
 
@@ -39,7 +39,7 @@ wav = tts.infer("שלום עולם", style_json_path="voices/female1.json")
 ONLY FOR NVIDIA GPUS!
 
 ```bash
-uv run python create_tensorrt.py --onnx_dir onnx_models --engine_dir trt_engines --precision fp16
+uv run python create_tensorrt.py --onnx_dir ./onnx_models --engine_dir trt_engines --precision fp16
 uv run python benchmark_trt.py --style_json voices/female1.json --steps 32
 uv run python test_gpu_onnx.py --compare --runs 3
 ```
@@ -48,7 +48,7 @@ Your project directory should look like this:
 
 ```
 Light-BlueTTS/
-├── phonikud-1.0.onnx              # from phonikud-onnx repo
+├── phonikud-1.0.int8.onnx         # from phonikud-onnx repo
 └── onnx_models/
     ├── backbone.onnx               # flow-matching backbone
     ├── backbone_keys.onnx          # backbone with style_keys (for CFG)

--- a/hebrew_inference_helper.py
+++ b/hebrew_inference_helper.py
@@ -26,7 +26,7 @@ class TTSConfig:
     # Model Paths
     onnx_dir: str = "onnx_models"
     config_path: str = "tts.json"
-    phonikud_path: str = "phonikud-1.0.onnx"
+    phonikud_path: str = "phonikud-1.0.int8.onnx"
     use_gpu: bool = False
     use_int8: bool = False
 
@@ -716,7 +716,7 @@ if __name__ == "__main__":
     
     parser = argparse.ArgumentParser()
     parser.add_argument("--onnx_dir", default="onnx_models")
-    parser.add_argument("--phonikud_path", default="phonikud-1.0.onnx")
+    parser.add_argument("--phonikud_path", default="phonikud-1.0.int8.onnx")
     parser.add_argument("--text", default="שלום עולם")
     parser.add_argument("--z_ref", default=None)
     parser.add_argument("--style_json", default="voices/male1.json")

--- a/run_onnx_inference.py
+++ b/run_onnx_inference.py
@@ -47,7 +47,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--onnx_dir", default="onnx_models")
     parser.add_argument("--config", default="tts.json", help="Path to tts.json config")
-    parser.add_argument("--phonikud_path", default="phonikud-1.0.onnx")
+    parser.add_argument("--phonikud_path", default="phonikud-1.0.int8.onnx")
     parser.add_argument("--z_ref", default=None)
     parser.add_argument("--style_json", default="voices/male1.json")
     parser.add_argument("--out", default="onnx_out.wav")


### PR DESCRIPTION
## Summary

- Fix `--repo-type` from invalid `onnx_model` to `model` in the `hf download` command
- Align `onnx_models` directory name consistently across README examples and code (`./onnx_model` → `./onnx_models`)
- Update default `phonikud_path` from `phonikud-1.0.onnx` to `phonikud-1.0.int8.onnx` to match the file actually available on HuggingFace

## Problem

Running the demo command from the README failed with:
```
onnxruntime.capi.onnxruntime_pybind11_state.InvalidProtobuf: Load model from . failed
```
Because `--phonikud_path .` passed a directory instead of a file, and the defaults in code pointed to filenames that don't match what the download instructions produce.

## Changes

- `README.md`: fix `--repo-type`, directory name, phonikud filename in directory listing, Python and TensorRT examples
- `hebrew_inference_helper.py`: update `TTSConfig.phonikud_path` default and `__main__` argparse default
- `run_onnx_inference.py`: update `--phonikud_path` argparse default