### PR TITLE
Add ONNX zero-shot voice style extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The PyPI package is **inference only** (ONNX TTS in Python). It does not ship tr
 pip install "blue-onnx"
 ```
 
+For Rust ONNX inference, see [blue-rs](https://github.com/thewh1teagle/blue-rs).
+
 **Inference with pip in three steps:** (1) install as above, (2) put ONNX in `./onnx_models` (see [Models](#models) — `hf download` from [`blue-onnx-v2`](https://huggingface.co/notmax123/blue-onnx-v2), or the experimental [INT8 bundle](https://huggingface.co/notmax123/bluev2-onnx-int8) into another folder), (3) copy a style JSON (e.g. from [voices/](https://github.com/maxmelichov/BlueTTS/tree/main/voices)) and Hebrew G2P `model.onnx` (see [Models](#models)), then use this from your project:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The PyPI package is **inference only** (ONNX TTS in Python). It does not ship tr
 pip install "blue-onnx"
 ```
 
-**Inference with pip in three steps:** (1) install as above, (2) put ONNX in `./onnx_models` (see [Models](#models) — `hf download` from `notmax123/blue-onnx-v2`), (3) copy a style JSON (e.g. from [voices/](https://github.com/maxmelichov/BlueTTS/tree/main/voices)) and Hebrew G2P `model.onnx` (see [Models](#models)), then use this from your project:
+**Inference with pip in three steps:** (1) install as above, (2) put ONNX in `./onnx_models` (see [Models](#models) — `hf download` from [`blue-onnx-v2`](https://huggingface.co/notmax123/blue-onnx-v2), or the experimental [INT8 bundle](https://huggingface.co/notmax123/bluev2-onnx-int8) into another folder), (3) copy a style JSON (e.g. from [voices/](https://github.com/maxmelichov/BlueTTS/tree/main/voices)) and Hebrew G2P `model.onnx` (see [Models](#models)), then use this from your project:
 
 ```python
 import soundfile as sf
@@ -63,13 +63,21 @@ The default environment uses the stock `onnxruntime` CPU wheel. **OpenVINO** and
 
 ## Models
 
-**ONNX bundle** ([notmax123/blue-onnx-v2](https://huggingface.co/notmax123/blue-onnx-v2)): the published graphs are **onnx-slim**–cleaned, **full precision** (not INT8). Do not substitute a `--int8` export from [exports/export_onnx.py](exports/export_onnx.py); that path is experimental and not recommended for quality.
+**FP32 bundle (recommended)** — [notmax123/blue-onnx-v2](https://huggingface.co/notmax123/blue-onnx-v2): **onnxslim**–cleaned, **full precision**. Includes the four core graphs (`text_encoder`, `vector_estimator`, `vocoder`, `duration_predictor`), runtime **`tts.json`** / **`vocab.json`**, and ONNX graphs for **zero-shot voice conversion** from a reference clip (`codec_encoder`, `style_encoder`, `duration_style_encoder`).
 
 ```bash
 uv run hf download notmax123/blue-onnx-v2 --repo-type model --local-dir ./onnx_models
 ```
 
-The Hub bundle does **not** include per-voice **style JSON**; use the sample `voices/*.json` from **this repository** (or on [GitHub](https://github.com/maxmelichov/BlueTTS/tree/main/voices)), or **export a new voice** from a reference clip (see [exports/README.md](exports/README.md), PyTorch weights below). If you use `pip` without `uv`, the same CLI is available after install because `blue-onnx` depends on `huggingface-hub` — run `hf download ...` with the same arguments and point `style_json` at a file under `voices/` (e.g. `voices/female1.json`).
+**INT8 bundle (experimental)** — [notmax123/bluev2-onnx-int8](https://huggingface.co/notmax123/bluev2-onnx-int8): weight-only quantized graphs for a smaller footprint; **not** slimmed after export. Same filenames and layout as the FP32 bundle—set `onnx_dir` to the downloaded folder. Prefer FP32 for best quality.
+
+```bash
+uv run hf download notmax123/bluev2-onnx-int8 --repo-type model --local-dir ./onnx_int8
+```
+
+Local export with [exports/export_onnx.py](exports/export_onnx.py): use `--slim` for FP32 (matches the published FP32 style) or `--int8` without `--slim` for INT8; INT8 remains experimental.
+
+The Hub bundles do **not** include per-voice **style JSON**; use the sample `voices/*.json` from **this repository** (or on [GitHub](https://github.com/maxmelichov/BlueTTS/tree/main/voices)), or **export a new voice** from a reference clip (see [exports/README.md](exports/README.md), PyTorch weights below). If you use `pip` without `uv`, the same CLI is available after install because `blue-onnx` depends on `huggingface-hub` — run `hf download ...` with the same arguments and point `style_json` at a file under `voices/` (e.g. `voices/female1.json`).
 
 **Optional**
 

--- a/examples/zero_shot.py
+++ b/examples/zero_shot.py
@@ -1,0 +1,45 @@
+"""
+Zero-shot voice style from a reference WAV using ONNX-only style extraction.
+
+Prepare the reference clip:
+    wget https://github.com/thewh1teagle/phonikud-chatterbox/releases/download/asset-files-v1/male1.wav -O ref.wav
+
+Prepare Hebrew G2P:
+    wget https://huggingface.co/thewh1teagle/renikud/resolve/main/model.onnx -O model.onnx
+
+Run:
+    uv run python examples/zero_shot.py
+"""
+
+from pathlib import Path
+
+import soundfile as sf
+
+from blue_onnx import load_text_to_speech
+from blue_onnx.style import style_from_wav
+
+Path("examples/out").mkdir(parents=True, exist_ok=True)
+
+onnx_dir = "onnx_models-int8"
+ref_wav = "ref.wav"
+renikud = "model.onnx"
+
+style = style_from_wav(ref_wav, onnx_dir=onnx_dir, config=f"{onnx_dir}/tts.json")
+tts = load_text_to_speech(onnx_dir=onnx_dir)
+if tts.g2p is not None:
+    tts.g2p = type(tts.g2p)(renikud)
+
+audio, _ = tts(
+    "שימו לב נוסעים יקרים, הרכבת תיכנס לתחנת תל אביב מרכז בעוד מספר דקות.",
+    lang="he",
+    style=style,
+    total_step=5,
+    cfg_scale=4.0,
+    text_is_phonemes=False,
+)
+if audio.ndim == 2:
+    audio = audio[0]
+
+out = "examples/out/zero_shot.wav"
+sf.write(out, audio, tts.sample_rate)
+print("Saved", out)

--- a/exports/export_onnx.py
+++ b/exports/export_onnx.py
@@ -9,7 +9,9 @@ Produces (in --onnx_dir):
 """
 import argparse
 import os
+import shutil
 import sys
+from typing import cast
 
 _ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if _ROOT not in sys.path:
@@ -25,6 +27,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from bluecodec import LatentDecoder1D
+from bluecodec.autoencoder.latent_encoder import LatentEncoder  # noqa: E402
 from training.dp.models.dp_network import DPNetwork
 from training.t2l.models.text_encoder import TextEncoder
 from training.t2l.models.vf_estimator import VectorFieldEstimator
@@ -85,7 +88,7 @@ class OnnxSafeMultiheadAttention(nn.Module):
         self.in_proj_bias = nn.Parameter(torch.empty(3 * embed_dim))
         self.out_proj = nn.Linear(embed_dim, embed_dim)
 
-    def forward(self, query, key, value, key_padding_mask=None, attn_mask=None):
+    def forward(self, query, key, value, key_padding_mask=None, attn_mask=None, need_weights=None, **kwargs):
         if not self.batch_first:
             query, key, value = (t.transpose(0, 1) for t in (query, key, value))
         B, T_q, _ = query.shape
@@ -202,6 +205,52 @@ class DPStyleWrapper(nn.Module):
         return self.dp(text_ids=text_ids, text_mask=text_mask, style_dp=style_dp)
 
 
+class CodecEncoderWithStats(nn.Module):
+    """Bakes latent compression and normalization for reference-style extraction."""
+
+    def __init__(self, encoder, mean, std, normalizer_scale, chunk_compress_factor):
+        super().__init__()
+        self.encoder = encoder
+        self.register_buffer("mean", mean.to(torch.float32).view(1, -1, 1))
+        self.register_buffer("std", std.to(torch.float32).view(1, -1, 1))
+        self.scale = float(normalizer_scale)
+        self.factor = int(chunk_compress_factor)
+
+    def forward(self, mel):
+        z = self.encoder(mel)
+        B, C, T = z.shape
+        pad = (self.factor - (T % self.factor)) % self.factor
+        if pad > 0:
+            z = F.pad(z, (0, pad))
+            T = T + pad
+        z = z.view(B, C, T // self.factor, self.factor).permute(0, 1, 3, 2).flatten(1, 2)
+        mean = cast(torch.Tensor, self.mean)
+        std = cast(torch.Tensor, self.std)
+        return ((z - mean) / std) * self.scale
+
+
+class DPReferenceStyleWrapper(nn.Module):
+    def __init__(self, dp):
+        super().__init__()
+        self.ref_encoder = dp.ref_encoder
+
+    def forward(self, z_ref, ref_mask):
+        B = z_ref.shape[0]
+        x = self.ref_encoder.input_proj(z_ref)
+        x = self.ref_encoder.convnext(x, mask=ref_mask)
+        kv = x.transpose(1, 2)
+        key_padding_mask = ref_mask.squeeze(1) == 0
+        q0 = self.ref_encoder.ref_keys.unsqueeze(0).expand(B, -1, -1)
+        q1, _ = self.ref_encoder.attn1(
+            query=q0, key=kv, value=kv, key_padding_mask=key_padding_mask, need_weights=False,
+        )
+        q2 = q0 + q1
+        out, _ = self.ref_encoder.attn2(
+            query=q2, key=kv, value=kv, key_padding_mask=key_padding_mask, need_weights=False,
+        )
+        return out
+
+
 # ── export + verify ──────────────────────────────────────────────────────────
 
 def export_one(model, out_path, inputs, input_names, output_names, dynamic_axes,
@@ -248,6 +297,56 @@ def verify(model, onnx_path, inputs, input_names, label, atol=1e-3, rtol=1e-2):
     return ok
 
 
+def export_style_extractors(
+    *,
+    onnx_dir,
+    ae_encoder,
+    ref_enc,
+    dp,
+    mean,
+    std,
+    cfg,
+    mel,
+    z_ref,
+    ref_mask,
+    do_slim,
+    do_int8,
+    do_verify,
+) -> bool:
+    """Export ONNX-only reference WAV -> style_ttl/style_dp helper graphs."""
+    all_ok = True
+    ccf = cfg["chunk_compress_factor"]
+
+    ae_enc_wrapped = CodecEncoderWithStats(
+        ae_encoder, mean, std, cfg.get("normalizer_scale", 1.0), chunk_compress_factor=ccf,
+    ).eval()
+    ae_enc_path = os.path.join(onnx_dir, "codec_encoder.onnx")
+    export_one(ae_enc_wrapped, ae_enc_path, (mel,), ["mel"], ["z_ref"], {
+        "mel": {2: "T_mel"}, "z_ref": {2: "T_ref"},
+    }, do_slim=do_slim, do_int8=do_int8)
+    if do_verify:
+        all_ok &= verify(ae_enc_wrapped, ae_enc_path, (mel,), ["mel"], "codec_encoder", atol=1e-4, rtol=1e-3)
+
+    se_inputs = (z_ref, ref_mask)
+    se_names = ["z_ref", "ref_mask"]
+    se_path = os.path.join(onnx_dir, "style_encoder.onnx")
+    export_one(ref_enc, se_path, se_inputs, se_names, ["style_ttl"], {
+        "z_ref": {2: "T_ref"}, "ref_mask": {2: "T_ref"},
+    }, do_slim=do_slim, do_int8=do_int8)
+    if do_verify:
+        all_ok &= verify(ref_enc, se_path, se_inputs, se_names, "style_encoder", atol=1e-4, rtol=1e-3)
+
+    dp_ref_wrapped = DPReferenceStyleWrapper(dp).eval()
+    dp_ref_path = os.path.join(onnx_dir, "duration_style_encoder.onnx")
+    export_one(dp_ref_wrapped, dp_ref_path, se_inputs, se_names, ["style_dp"], {
+        "z_ref": {2: "T_ref"}, "ref_mask": {2: "T_ref"},
+    }, do_slim=do_slim, do_int8=do_int8)
+    if do_verify:
+        all_ok &= verify(dp_ref_wrapped, dp_ref_path, se_inputs, se_names, "duration_style_encoder", atol=1e-4, rtol=1e-3)
+
+    return all_ok
+
+
 # ── main ─────────────────────────────────────────────────────────────────────
 
 def main():
@@ -257,7 +356,7 @@ def main():
     p.add_argument("--ttl_ckpt", required=True, help="text2latent checkpoint (.pt / .safetensors)")
     p.add_argument("--ae_ckpt", required=True, help="audio codec checkpoint")
     p.add_argument("--dp_ckpt", required=True, help="duration predictor checkpoint")
-    p.add_argument("--stats", required=True, help="normalization stats .pt (mean/std)")
+    p.add_argument("--stats", required=True, help="normalization stats .pt/.safetensors (mean/std)")
     p.add_argument("--slim", action="store_true", help="run onnxslim after export")
     p.add_argument("--int8", action="store_true", help="weight-only QUInt8 quantization")
     p.add_argument("--no-verify", dest="no_verify", action="store_true")
@@ -266,6 +365,8 @@ def main():
     cfg = load_ttl_config(args.config)
     print(f"[INFO] config: {args.config} (v{cfg['full_config'].get('tts_version', '?')})")
     os.makedirs(args.onnx_dir, exist_ok=True)
+    shutil.copyfile(args.config, os.path.join(args.onnx_dir, "tts.json"))
+    shutil.copyfile(os.path.join(_ROOT, "src", "vocab.json"), os.path.join(args.onnx_dir, "vocab.json"))
 
     # ---- load checkpoints ---------------------------------------------------
     t2l = _load_state(args.ttl_ckpt)
@@ -277,7 +378,7 @@ def main():
         raise RuntimeError(f"u_text/u_ref missing in {args.ttl_ckpt}; re-export with uncond params.")
     print(f"[INFO] baking uncond: u_text {tuple(u_text.shape)}, u_ref {tuple(u_ref.shape)}")
 
-    stats = torch.load(args.stats, map_location="cpu", weights_only=False)
+    stats = _load_state(args.stats)
     mean = stats["mean"].to(torch.float32)
     std = stats["std"].to(torch.float32)
 
@@ -302,11 +403,10 @@ def main():
 
     ref_enc = ReferenceEncoder(
         in_channels=compressed, d_model=cfg["se_d_model"],
-        hidden_dim=cfg.get("re_hidden_dim", 1024),
-        num_blocks=cfg.get("re_n_blocks", 6),
+        hidden_dim=cfg["se_hidden_dim"],
+        num_blocks=cfg["se_num_blocks"],
         num_tokens=n_style,
-        num_heads=cfg.get("re_n_heads", 2),
-        kernel_size=cfg.get("re_kernel_size", 5),
+        num_heads=cfg["se_n_heads"],
     ).eval()
     _load_into(ref_enc, t2l, "reference_encoder")
     _replace_mha(ref_enc)
@@ -322,6 +422,14 @@ def main():
 
     vocoder = LatentDecoder1D(cfg=cfg["ae_dec_cfg"]).eval()
     _load_into(vocoder, ae, "decoder")
+
+    ae_encoder = LatentEncoder(cfg=cfg["ae_enc_cfg"]).eval()
+    ae_enc_state = _submodule(ae, "encoder")
+    if ae_enc_state is None:
+        ae_enc_state = ae
+    if not isinstance(ae_enc_state, dict):
+        raise TypeError(f"AE encoder state must be a state dict, got {type(ae_enc_state).__name__}")
+    ae_encoder.load_state_dict(ae_enc_state, strict=True)
 
     dp = DPNetwork(
         vocab_size=dp_vocab_size,
@@ -356,6 +464,8 @@ def main():
     cfg_scale = torch.tensor([4.0])
     style_dp_s = torch.randn(B, cfg["dp_style_tokens"], cfg["dp_style_dim"])
     z_pred = torch.randn(B, compressed, T_lat)
+    mel = torch.randn(B, cfg["ae_n_fft"] // 2 + 1 + cfg["ae_n_mels"], 300)
+    ref_mask = torch.ones(B, 1, T_lat)
 
     do_verify = not args.no_verify and not args.int8
     if args.int8 and not args.no_verify:
@@ -409,6 +519,22 @@ def main():
     }, do_slim=args.slim, do_int8=args.int8)
     if do_verify:
         all_ok &= verify(dp_wrapped, dp_path, dp_inputs, dp_names, "duration_predictor", atol=1e-4, rtol=1e-3)
+
+    all_ok &= export_style_extractors(
+        onnx_dir=args.onnx_dir,
+        ae_encoder=ae_encoder,
+        ref_enc=ref_enc,
+        dp=dp,
+        mean=mean,
+        std=std,
+        cfg=cfg,
+        mel=mel,
+        z_ref=z_pred,
+        ref_mask=ref_mask,
+        do_slim=args.slim,
+        do_int8=args.int8,
+        do_verify=do_verify,
+    )
 
     if do_verify:
         print("\n" + ("[PASS] All match." if all_ok else "[FAIL] Mismatch."))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "numpy",
+    "librosa",
     "onnxruntime",
     "soundfile",
     "huggingface-hub>=0.26.0",
@@ -35,7 +36,6 @@ tensorrt = [
 ]
 export = [
     "bluecodec",
-    "librosa",
     "onnx>=1.17.0",
     "onnxslim>=0.1.0",
     "safetensors>=0.4.0",
@@ -47,8 +47,6 @@ export = [
 # (the published package is inference-only).
 
 [tool.uv]
-# Repo is scripts + src packages, not a single importable `blue` package tree (avoids uv_build errors).
-package = false
 # Do not install `[dependency-groups] dev` on every `uv sync` (matches behavior before a proper `dev` group existed).
 default-groups = []
 # Default `onnxruntime` and `onnxruntime-gpu` / `onnxruntime-openvino` are mutually exclusive at import time.

--- a/src/blue_onnx/style.py
+++ b/src/blue_onnx/style.py
@@ -1,0 +1,192 @@
+"""ONNX-only voice-style extraction for BlueTTS."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import librosa
+import numpy as np
+import onnxruntime as ort
+import soundfile as sf
+
+from . import Style
+
+
+def _stats(a: np.ndarray) -> dict[str, float]:
+    return {
+        "mean": float(a.mean()),
+        "std": float(a.std()),
+        "min": float(a.min()),
+        "max": float(a.max()),
+    }
+
+
+def style_from_payload(payload: dict[str, Any]) -> Style:
+    """Convert a voice JSON payload into a runtime :class:`blue_onnx.Style`."""
+    ttl = np.asarray(payload["style_ttl"]["data"], dtype=np.float32).reshape(payload["style_ttl"]["dims"])
+    dp = np.asarray(payload["style_dp"]["data"], dtype=np.float32).reshape(payload["style_dp"]["dims"])
+    return Style(ttl, dp)
+
+
+def payload_from_style(style: Style, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Convert a runtime :class:`blue_onnx.Style` into voice JSON payload data."""
+    style_ttl = np.asarray(style.ttl, dtype=np.float32)
+    style_dp = np.asarray(style.dp, dtype=np.float32)
+    return {
+        "style_ttl": {"data": style_ttl.tolist(), "dims": list(style_ttl.shape)},
+        "style_dp": {"data": style_dp.tolist(), "dims": list(style_dp.shape)},
+        "metadata": metadata or {},
+    }
+
+
+def _load_config(config: str | dict[str, Any]) -> dict[str, Any]:
+    if isinstance(config, dict):
+        full = config
+    else:
+        with open(config, "r") as f:
+            full = json.load(f)
+    ae = full.get("ae", {})
+    ttl = full.get("ttl", {})
+    enc = ae.get("encoder", {})
+    spec = enc.get("spec_processor", {})
+    return {
+        "full_config": full,
+        "sample_rate": int(ae.get("sample_rate", 44100)),
+        "n_fft": int(spec.get("n_fft", 2048)),
+        "win_length": int(spec.get("win_length", spec.get("n_fft", 2048))),
+        "hop_length": int(spec.get("hop_length", 512)),
+        "n_mels": int(spec.get("n_mels", 1253)),
+        "chunk_compress_factor": int(ttl.get("chunk_compress_factor", ae.get("chunk_compress_factor", 1))),
+    }
+
+
+def _read_wav_mono(path: str, sample_rate: int) -> np.ndarray:
+    wav, sr = sf.read(path, always_2d=True, dtype="float32")
+    wav = wav.mean(axis=1)
+    if int(sr) != int(sample_rate):
+        wav = librosa.resample(wav, orig_sr=int(sr), target_sr=int(sample_rate), res_type="kaiser_best")
+    return np.asarray(wav, dtype=np.float32)
+
+
+def _linear_mel_features(wav: np.ndarray, *, sample_rate: int, n_fft: int, win_length: int, hop_length: int, n_mels: int) -> np.ndarray:
+    spec = np.abs(
+        librosa.stft(
+            wav,
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window="hann",
+            center=True,
+            pad_mode="reflect",
+        )
+    ).astype(np.float32)
+    mel_basis = librosa.filters.mel(
+        sr=sample_rate,
+        n_fft=n_fft,
+        n_mels=n_mels,
+        fmin=0.0,
+        fmax=None,
+        htk=True,
+        norm=None,
+    ).astype(np.float32)
+    mel = np.matmul(mel_basis, spec)
+    log_spec = np.log(np.maximum(spec, 1e-5))
+    log_mel = np.log(np.maximum(mel, 1e-5))
+    return np.concatenate([log_spec, log_mel], axis=0)[None].astype(np.float32)
+
+
+def _trim_reference_latents(z: np.ndarray, *, max_frames: int = 150) -> np.ndarray:
+    t = z.shape[2]
+    tail = max(2, int(t * 0.05))
+    t_trim = max(1, t - tail)
+    if t_trim < t:
+        z = z[:, :, :t_trim]
+    if z.shape[2] > max_frames:
+        z = z[:, :, :max_frames]
+    return z
+
+
+def _session(path: str, providers: list[str] | None = None) -> ort.InferenceSession:
+    return ort.InferenceSession(path, providers=providers or ["CPUExecutionProvider"])
+
+
+class VoiceStyleExtractor:
+    """Extract ``Style`` from a WAV using only ONNX Runtime, soundfile, librosa, and numpy."""
+
+    def __init__(
+        self,
+        onnx_dir: str = "onnx_models",
+        *,
+        config: str | dict[str, Any] = "config/tts.json",
+        providers: list[str] | None = None,
+        codec_encoder: str | None = None,
+        style_encoder: str | None = None,
+        duration_style_encoder: str | None = None,
+    ):
+        self.onnx_dir = onnx_dir
+        self.cfg = _load_config(config)
+        self.codec_encoder = _session(codec_encoder or os.path.join(onnx_dir, "codec_encoder.onnx"), providers)
+        self.style_encoder = _session(style_encoder or os.path.join(onnx_dir, "style_encoder.onnx"), providers)
+        self.duration_style_encoder = _session(
+            duration_style_encoder or os.path.join(onnx_dir, "duration_style_encoder.onnx"),
+            providers,
+        )
+
+    def _z_ref(self, ref_wav: str) -> np.ndarray:
+        wav = _read_wav_mono(ref_wav, self.cfg["sample_rate"])
+        mel = _linear_mel_features(
+            wav,
+            sample_rate=self.cfg["sample_rate"],
+            n_fft=self.cfg["n_fft"],
+            win_length=self.cfg["win_length"],
+            hop_length=self.cfg["hop_length"],
+            n_mels=self.cfg["n_mels"],
+        )
+        frames = (mel.shape[2] // self.cfg["chunk_compress_factor"]) * self.cfg["chunk_compress_factor"]
+        if frames < mel.shape[2]:
+            mel = mel[:, :, :frames]
+        z_ref = self.codec_encoder.run(None, {"mel": mel})[0].astype(np.float32)
+        if not np.isfinite(z_ref).all():
+            raise RuntimeError("non-finite reference latents")
+        return z_ref
+
+    def payload_from_wav(self, ref_wav: str) -> dict[str, Any]:
+        z_ref = _trim_reference_latents(self._z_ref(ref_wav))
+        ref_mask = np.ones((z_ref.shape[0], 1, z_ref.shape[2]), dtype=np.float32)
+        style_ttl = self.style_encoder.run(None, {"z_ref": z_ref, "ref_mask": ref_mask})[0].astype(np.float32)
+        style_dp = self.duration_style_encoder.run(None, {"z_ref": z_ref, "ref_mask": ref_mask})[0].astype(np.float32)
+        metadata = {
+            "sr": self.cfg["sample_rate"],
+            "ref_wav": os.path.abspath(ref_wav),
+            "z_ref_norm_shape": list(z_ref.shape),
+            "style_ttl_stats": _stats(style_ttl),
+            "style_dp_stats": _stats(style_dp),
+        }
+        return payload_from_style(Style(style_ttl, style_dp), metadata=metadata)
+
+    def from_wav(self, ref_wav: str) -> Style:
+        """Extract a runtime ``Style`` object from a reference WAV."""
+        return style_from_payload(self.payload_from_wav(ref_wav))
+
+
+def export_voice_style(
+    ref_wav: str,
+    *,
+    onnx_dir: str = "onnx_models",
+    config: str | dict[str, Any] = "config/tts.json",
+    providers: list[str] | None = None,
+) -> dict[str, Any]:
+    """Return a voice JSON payload from a reference WAV using ONNX Runtime only."""
+    return VoiceStyleExtractor(onnx_dir=onnx_dir, config=config, providers=providers).payload_from_wav(ref_wav)
+
+
+def style_from_wav(
+    ref_wav: str,
+    *,
+    onnx_dir: str = "onnx_models",
+    config: str | dict[str, Any] = "config/tts.json",
+    providers: list[str] | None = None,
+) -> Style:
+    """Return a runtime ``Style`` object from a reference WAV using ONNX Runtime only."""
+    return VoiceStyleExtractor(onnx_dir=onnx_dir, config=config, providers=providers).from_wav(ref_wav)

--- a/uv.lock
+++ b/uv.lock
@@ -131,10 +131,11 @@ wheels = [
 [[package]]
 name = "blue-onnx"
 version = "0.2.5"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "espeakng-loader" },
     { name = "huggingface-hub" },
+    { name = "librosa" },
     { name = "numpy" },
     { name = "onnx" },
     { name = "onnxruntime" },
@@ -147,7 +148,6 @@ dependencies = [
 [package.optional-dependencies]
 export = [
     { name = "bluecodec" },
-    { name = "librosa" },
     { name = "onnx" },
     { name = "onnxslim" },
     { name = "safetensors" },
@@ -174,7 +174,7 @@ requires-dist = [
     { name = "bluecodec", marker = "extra == 'export'", git = "https://github.com/maxmelichov/blue-codec.git" },
     { name = "espeakng-loader", specifier = ">=0.2.4" },
     { name = "huggingface-hub", specifier = ">=0.26.0" },
-    { name = "librosa", marker = "extra == 'export'" },
+    { name = "librosa" },
     { name = "numpy" },
     { name = "onnx", specifier = ">=1.20.1" },
     { name = "onnx", marker = "extra == 'export'", specifier = ">=1.17.0" },


### PR DESCRIPTION
## Summary
- export ONNX graphs for reference WAV style extraction
- add ONNX-only style extraction helper using soundfile/librosa/onnxruntime
- add zero-shot example that extracts style from a reference WAV and synthesizes audio

## Zero-shot style model sizes
INT8 style extraction graphs:
- codec_encoder.onnx: ~25M
- style_encoder.onnx: ~3.8M
- duration_style_encoder.onnx: ~236K
- total style overhead: ~29M

FP32 style extraction graphs before INT8 quantization:
- codec_encoder.onnx: ~98M
- style_encoder.onnx: ~14M
- duration_style_encoder.onnx: ~622K
- total style overhead: ~112M

Full INT8 ONNX folder with synthesis + zero-shot style extraction is ~104M. Synthesis-only INT8 remains ~76M.

## Testing
- uv run python -m py_compile exports/export_onnx.py examples/zero_shot.py src/blue_onnx/style.py
- uv run python examples/zero_shot.py
